### PR TITLE
Fix segmentation for 1-channel model outputs

### DIFF
--- a/src/deepness/processing/map_processor/map_processor_segmentation.py
+++ b/src/deepness/processing/map_processor/map_processor_segmentation.py
@@ -136,5 +136,8 @@ class MapProcessorSegmentation(MapProcessorWithModel):
         result = self.model.process(tile_img)
 
         result[result < self.segmentation_parameters.pixel_classification__probability_threshold] = 0.0
-        result = np.argmax(result, axis=0)
+        if (result.shape[0] == 1):
+            result = (result != 0).astype(int)[0]         
+        else:
+            result = np.argmax(result, axis=0)
         return result

--- a/src/deepness/processing/models/segmentor.py
+++ b/src/deepness/processing/models/segmentor.py
@@ -72,7 +72,13 @@ class Segmentor(ModelBase):
             Number of channels in the output layer
         """
         if len(self.outputs_layers) == 1:
-            return self.outputs_layers[0].shape[-3]
+            n_output_channels = self.outputs_layers[0].shape[-3]
+            # Support models that return a single output layer, which is converted to 
+            # a binary mask.
+            if n_output_channels == 1:
+                return 2
+            else:
+                return n_output_channels
         else:
             raise NotImplementedError("Model with multiple output layers is not supported! Use only one output layer.")
 


### PR DESCRIPTION
The original implementation of the segmentation model in Deepness does not work for models which have only single output channels, i.e. single channel which signifies the probability of single class. This is because **argmax** in the map_processor_segmentation will take max values on 0-axis, and in this case all max values are on axis 0. Therefore, the resulting array will be full of zeros.

Additionally, the way channel get_number_of_output_channels work, does not support single class either as a output array with 1 channel actually essentially represents two classes: _class_ and _not class_. 

Note, that the suggested fix will not work if no threshold is used. Then everything will be classified as _class_. The suggested fix will essentially produce a binary mask. 