### PR TITLE
Fix the number of output channels for super-resolution models and disable output format options

### DIFF
--- a/src/deepness/deepness_dockwidget.py
+++ b/src/deepness/deepness_dockwidget.py
@@ -229,6 +229,8 @@ class DeepnessDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         self.mGroupBox_detectionParameters.setEnabled(detection_enabled)
         self.mGroupBox_regressionParameters.setEnabled(regression_enabled)
         self.mGroupBox_superresolutionParameters.setEnabled(superresolution_enabled)
+        # Disable output format options for super-resolution models.
+        self.mGroupBox_6.setEnabled(not superresolution_enabled)
 
     def _detector_type_changed(self):
         detector_type = DetectorType(self.comboBox_detectorType.currentText())
@@ -364,6 +366,8 @@ class DeepnessDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
                 output_0_shape = self._model.get_output_shape()
                 scale_factor = output_0_shape[-1] / input_size_px
                 self.doubleSpinBox_superresolutionScaleFactor.setValue(int(scale_factor))
+                # Disable output format options for super-resolution models
+                self.mGroupBox_6.setEnabled(False)
         except Exception as e:
             if IS_DEBUG:
                 raise e

--- a/src/deepness/processing/map_processor/map_processor_superresolution.py
+++ b/src/deepness/processing/map_processor/map_processor_superresolution.py
@@ -38,7 +38,7 @@ class MapProcessorSuperresolution(MapProcessorWithModel):
         return self._result_imgs
 
     def _run(self) -> MapProcessingResult:
-        number_of_output_channels = len(self._get_indexes_of_model_output_channels_to_create())
+        number_of_output_channels = self.model.get_number_of_output_channels()
         final_shape_px = (int(self.img_size_y_pixels*self.superresolution_parameters.scale_factor), int(self.img_size_x_pixels*self.superresolution_parameters.scale_factor), number_of_output_channels)
 
         # NOTE: consider whether we can use float16/uint16 as datatype


### PR DESCRIPTION
This fixes the number of output channels for super-resolution models and disables UI for output format options when super-resolution model is used. Output format options switch back on when another model type is changed in the UI. 

Fix for https://github.com/PUTvision/qgis-plugin-deepness/issues/120#issue-2014233021