### PR TITLE
Replace setEnabled with setVisible for menu blocks

### DIFF
--- a/src/deepness/deepness_dockwidget.py
+++ b/src/deepness/deepness_dockwidget.py
@@ -225,10 +225,10 @@ class DeepnessDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         else:
             raise Exception(f"Unsupported model type ({model_type})!")
 
-        self.mGroupBox_segmentationParameters.setEnabled(segmentation_enabled)
-        self.mGroupBox_detectionParameters.setEnabled(detection_enabled)
-        self.mGroupBox_regressionParameters.setEnabled(regression_enabled)
-        self.mGroupBox_superresolutionParameters.setEnabled(superresolution_enabled)
+        self.mGroupBox_segmentationParameters.setVisible(segmentation_enabled)
+        self.mGroupBox_detectionParameters.setVisible(detection_enabled)
+        self.mGroupBox_regressionParameters.setVisible(regression_enabled)
+        self.mGroupBox_superresolutionParameters.setVisible(superresolution_enabled)
         # Disable output format options for super-resolution models.
         self.mGroupBox_6.setEnabled(not superresolution_enabled)
 

--- a/src/deepness/processing/processing_utils.py
+++ b/src/deepness/processing/processing_utils.py
@@ -95,7 +95,7 @@ def get_tile_image(
             extent,
             image_size[0], image_size[1])
         block_height, block_width = raster_block.height(), raster_block.width()
-        if block_width == 0 or block_width == 0:
+        if block_height == 0 or block_width == 0:
             raise Exception("No data on layer within the expected extent!")
         return raster_block
 


### PR DESCRIPTION
The `setEnabled` parameter is replaced with `setVisible` for main menu blocks like ` mGroupBox_segmentationParameters` or `mGroupBox_detectionParameters`.

This is a UX suggestion reported by the community.