### PR TITLE
Update dataset URL in car detection tutorial

### DIFF
--- a/tutorials/detection/cars_yolov7/car_detection__prepare_and_train.ipynb
+++ b/tutorials/detection/cars_yolov7/car_detection__prepare_and_train.ipynb
@@ -66,7 +66,7 @@
     "\n",
     "Download manually ITCVD dataset.\n",
     "\n",
-    "At the moment of writing available at https://easy.dans.knaw.nl/ui/datasets/id/easy-dataset:157920/tab/2\n",
+    "At the moment of writing available at https://doi.org/10.17026/dans-xnc-h2fu\n",
     "\n",
     "Create subdirectory for our data:\n",
     "```\n",


### PR DESCRIPTION
ITCVD dataset moved to new URL. Adjusted it in the car detection tutorial notebook.