### PR TITLE
Fix/dependency updates

### DIFF
--- a/src/deepness/dialogs/packages_installer/packages_installer_dialog.py
+++ b/src/deepness/dialogs/packages_installer/packages_installer_dialog.py
@@ -346,7 +346,7 @@ def check_pip_installed() -> bool:
 def check_required_packages_and_install_if_necessary(iface):
     os.makedirs(PACKAGES_INSTALL_DIR, exist_ok=True)
     if PACKAGES_INSTALL_DIR not in sys.path:
-        sys.path.append(PACKAGES_INSTALL_DIR)  # TODO: check for a less intrusive way to do this
+        sys.path.insert(0, PACKAGES_INSTALL_DIR)  # ensure plugin packages take priority over system packages
 
     if are_packages_importable():
         # if packages are importable we are fine, nothing more to do then

--- a/src/deepness/processing/models/detector.py
+++ b/src/deepness/processing/models/detector.py
@@ -149,7 +149,8 @@ class Detector(ModelBase):
         int
             Number of output channels
         """
-        class_names = self.get_outputs_channel_names()[0]
+        all_channel_names = self.get_outputs_channel_names()
+        class_names = all_channel_names[0] if all_channel_names else None
         if class_names is not None:
             return [len(class_names)]  # If class names are specified, we expect to have exactly this number of channels as specidied
 

--- a/src/deepness/python_requirements/requirements.txt
+++ b/src/deepness/python_requirements/requirements.txt
@@ -2,8 +2,8 @@
 #numpy  # available already from qgis repo
 #pyqt5  # available already from qgis repo
 
-
-# NOTE - for the time being - keep the same packages and versions in the `packages_installer_dialog.py`
-numpy<2.0.0
-onnxruntime-gpu>=1.12.1,<=1.17.0
-opencv-python-headless>=4.5.5.64,<=4.9.0.80
+# NOTE - keep the same packages and versions in the `packages_installer_dialog.py`
+# onnxruntime >= 1.23.0 required for opset 21/22/23 support
+numpy>=1.24.0
+onnxruntime-gpu>=1.23.0
+opencv-python-headless>=4.10.0


### PR DESCRIPTION
The fix contains:

- Bump onnxruntime lower bound to >=1.23.0 (required for opset 21/22/23 support)
- Bump opencv-python-headless lower bound to >=4.10.0
- Remove upper version caps that prevented installation of current releases
- Fix sys.path.append -> sys.path.insert(0,...) so plugin env takes priority
  over OSGeo4W system-installed onnxruntime
- Fix IndexError in detector.py: get_outputs_channel_names() can return None
  or empty list; accessing [0] directly caused 'list index out of range' when
  loading models without class_names metadata"